### PR TITLE
Document copy feature for auditionee details

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -237,6 +237,15 @@ rating, and tags. It emphasises safe execution through assertions that guarantee
 
 Refer to `docs/diagrams/FindFeature.puml` for the detailed sequence diagram.
 
+### Copy feature
+Copies auditionee details to the system clipboard in a formatted table. You can optionally filter by instrument and
+limit to top performers by rating.
+The copy feature copies auditionee details, allowing for 2 parameters, `b/COUNT` and `i/INSTRUMENT` for the top `COUNT` auditionees playing `INSTRUMENT`. 
+
+1. `CopyCommandParser` splits the arguments on whitespace.
+2. `CopyCommand` filters the list of auditionees, generates the string, and copies it to device clipboard.
+3. The command returns a summary message showing how many auditionees has been copied.
+
 ### \[Proposed\] Undo/redo feature
 
 #### Proposed Implementation


### PR DESCRIPTION
Added details about the copy feature for auditionee details, including parameters and command flow.
closes #128 